### PR TITLE
Rename the Swift binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 !*.xcworkspace/contents.xcworkspacedata
 swift/main
 swift/build
+/aperture

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class Aperture {
   }
 
   getAudioSources() {
-    return execa.stderr(path.join(__dirname, 'swift/main'), ['list-audio-devices']).then(stderr => {
+    return execa.stderr(path.join(__dirname, 'aperture'), ['list-audio-devices']).then(stderr => {
       try {
         return JSON.parse(stderr);
       } catch (err) {
@@ -64,7 +64,7 @@ class Aperture {
         audioSourceId
       ];
 
-      this.recorder = execa(path.join(__dirname, 'swift', 'main'), recorderOpts);
+      this.recorder = execa(path.join(__dirname, 'aperture'), recorderOpts);
 
       const timeout = setTimeout(() => {
         // `.stopRecording()` was called already

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "test": "xo",
-    "build": "cd swift && xcodebuild archive -derivedDataPath $(mktemp -d) -scheme aperture",
+    "build": "cd swift && xcodebuild archive -derivedDataPath $(mktemp -d) -scheme aperture && mv main ../aperture",
     "prepublish": "npm run build"
   },
   "files": [
     "index.js",
-    "swift/main"
+    "aperture"
   ],
   "dependencies": {
     "execa": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "xo",
-    "build": "cd swift && xcodebuild archive -derivedDataPath $(mktemp -d) -scheme aperture && mv main ../aperture",
+    "build": "cd swift && xcodebuild archive -derivedDataPath $(mktemp -d) -scheme aperture",
     "prepublish": "npm run build"
   },
   "files": [

--- a/swift/aperture.xcodeproj/project.pbxproj
+++ b/swift/aperture.xcodeproj/project.pbxproj
@@ -13,18 +13,6 @@
 		E3A8F9E11E46F9C000C6C5FC /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A8F9E01E46F9C000C6C5FC /* util.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		E3A310791E450D3600D314DD /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		E3A3107B1E450D3600D314DD /* aperture */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = aperture; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3A310851E450DC800D314DD /* DeviceList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceList.swift; sourceTree = "<group>"; };
@@ -83,7 +71,6 @@
 			buildPhases = (
 				E3A310771E450D3600D314DD /* Sources */,
 				E3A310781E450D3600D314DD /* Frameworks */,
-				E3A310791E450D3600D314DD /* CopyFiles */,
 				E325A4461E450E5E0016DB84 /* ShellScript */,
 			);
 			buildRules = (
@@ -141,7 +128,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "cp \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_NAME}\" main";
+			shellScript = "cp \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_NAME}\" ../aperture";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/swift/aperture/main.swift
+++ b/swift/aperture/main.swift
@@ -55,10 +55,11 @@ func record() throws {
 }
 
 func usage() {
-  print("usage: main <list-audio-devices | <destinationPath> <fps> <crop-rect-coordinates> <show-cursor> <highlight-clicks> <display-id> <audio-device-id>>")
-  print("examples: main ./file.mp4 30 0:0:100:100 true false 1846519 'AppleHDAEngineInput:1B,0,1,0:1'")
-  print("          main ./file.mp4 30 none true false main none")
-  print("          main list-audio-devices")
+  let name = CommandLine.arguments.first?.components(separatedBy: "/").last ?? "main"
+  print("usage: \(name) <list-audio-devices | <destinationPath> <fps> <crop-rect-coordinates> <show-cursor> <highlight-clicks> <display-id> <audio-device-id>>")
+  print("examples: \(name) ./file.mp4 30 0:0:100:100 true false 1846519 'AppleHDAEngineInput:1B,0,1,0:1'")
+  print("          \(name) ./file.mp4 30 none true false main none")
+  print("          \(name) list-audio-devices")
 }
 
 let numberOfArgs = CommandLine.arguments.count

--- a/swift/aperture/main.swift
+++ b/swift/aperture/main.swift
@@ -55,11 +55,10 @@ func record() throws {
 }
 
 func usage() {
-  let name = CommandLine.arguments.first?.components(separatedBy: "/").last ?? "main"
-  print("usage: \(name) <list-audio-devices | <destinationPath> <fps> <crop-rect-coordinates> <show-cursor> <highlight-clicks> <display-id> <audio-device-id>>")
-  print("examples: \(name) ./file.mp4 30 0:0:100:100 true false 1846519 'AppleHDAEngineInput:1B,0,1,0:1'")
-  print("          \(name) ./file.mp4 30 none true false main none")
-  print("          \(name) list-audio-devices")
+  print("usage: aperture <list-audio-devices | <destinationPath> <fps> <crop-rect-coordinates> <show-cursor> <highlight-clicks> <display-id> <audio-device-id>>")
+  print("examples: aperture ./file.mp4 30 0:0:100:100 true false 1846519 'AppleHDAEngineInput:1B,0,1,0:1'")
+  print("          aperture ./file.mp4 30 none true false main none")
+  print("          aperture list-audio-devices")
 }
 
 let numberOfArgs = CommandLine.arguments.count


### PR DESCRIPTION
This PR changes the main binary to `aperture` so that you know what process this is in your acitivity monitor, currently it was just "main", which is a bit confusing 😄 

See here for an example (before):
![kapture 2017-05-30 at 2 55 54](https://cloud.githubusercontent.com/assets/5027156/26564626/8b089afc-44e3-11e7-9b38-802e9ffeba7e.gif)

~Also, seems like the processes aren't exited correctly? 🤔  when playing around, i had 10's of `main` processes in my activity monitor 😕~

see #35 👍 