### PR TITLE
Exit process on request

### DIFF
--- a/swift/aperture/main.swift
+++ b/swift/aperture/main.swift
@@ -4,6 +4,7 @@ var recorder: Recorder!
 
 func quit(_: Int32) {
   recorder.stop()
+  // See https://github.com/wulkano/aperture/pull/35 for more info
   exit(0)
 }
 

--- a/swift/aperture/main.swift
+++ b/swift/aperture/main.swift
@@ -4,6 +4,7 @@ var recorder: Recorder!
 
 func quit(_: Int32) {
   recorder.stop()
+  exit(0)
 }
 
 func record() throws {


### PR DESCRIPTION
If you run `node example.js` and ctrl+c (quit) before recorder.stopRecording() is called, the swift process won't be killed.

I think that's because execa kills it with the [default kill code](https://nodejs.org/api/child_process.html#child_process_child_kill_signal) **SIGTERM**

which is catched here: https://github.com/wulkano/aperture/compare/master...albinekb:exit-code?expand=1#diff-f4030c3d0a3c8d0746ab9fdabb019bebL48

and because that handler is there, it won't quit.

With this change it ensures that the process will always die 👍 