### PR TITLE
Fix example file

### DIFF
--- a/example.js
+++ b/example.js
@@ -7,7 +7,8 @@ async function main() {
   const recorder = aperture();
   console.log('Audio sources:', await recorder.getAudioSources());
   console.log('Recording for 5 seconds');
-  recorder.startRecording();
+  await recorder.startRecording();
+  console.log('Recording started');
   await delay(5000);
   const fp = await recorder.stopRecording();
   fs.renameSync(fp, 'recording.mp4');


### PR DESCRIPTION
Added await to `startRecording`, otherwise the recording won't be ~5s, since it takes some time to start the recording 😄 

before:
```sh
❯ node example.js
Audio sources: [ { id: 'AppleHDAEngineInput:1B,0,1,0:1',
    name: 'Built-in Microphone' } ]
Recording for 5 seconds
Video saved in the current directory

~/Devel/git/aperture update-example
❯ mediainfo --Inform="Video;%Duration%" recording.mp4
3300
```
**3.3s**

After
```sh
❯ node example.js
Audio sources: [ { id: 'AppleHDAEngineInput:1B,0,1,0:1',
    name: 'Built-in Microphone' } ]
Recording for 5 seconds
Recording started
Video saved in the current directory

~/Devel/git/aperture update-example
❯ mediainfo --Inform="Video;%Duration%" recording.mp4
5100
```
**5.1s**