### PR TITLE
Initial Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@
 $ npm install aperture
 ```
 
-requires: *macOS: 10.10 or later.* | *Windows: ffmpeg*
+*Requires minimum macOS 10.10 or Windows 7.*
 
 
 ## Usage
 
 ```js
 const aperture = require('aperture')({
-  // ffmpegBinary is *required* on Windows
   ffmpegBinary: process.platform === 'win32' ? 'C:\\path\\to\\ffmpeg.exe' : null,
 });
 
@@ -52,7 +51,7 @@ See [`example.js`](example.js) if you want to quickly try it out. *(The example 
 ##### ffmpegBinary
 
 Type: `string`<br>
-**Required on windows**
+**Required on Windows**
 
 Absolute path to the `ffmpeg.exe` binary.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p>
   <h1 align="center">Aperture</h1>
-  <h4 align="center">Record the screen on macOS</h4>
+  <h4 align="center">Record the screen on macOS & Windows</h4>
   <p align="center"><a href="https://github.com/sindresorhus/xo"><img src="https://img.shields.io/badge/code_style-XO-5ed9c7.svg" alt="XO code style"></a></p>
 </p>
 
@@ -11,13 +11,16 @@
 $ npm install aperture
 ```
 
-*Requires macOS 10.10 or later.*
+requires: *macOS: 10.10 or later.* | *Windows: ffmpeg*
 
 
 ## Usage
 
 ```js
-const aperture = require('aperture')();
+const aperture = require('aperture')({
+  // ffmpegBinary is *required* on Windows
+  ffmpegBinary: process.platform === 'win32' ? 'C:\\path\\to\\ffmpeg.exe' : null,
+});
 
 const options = {
   fps: 30,
@@ -42,7 +45,16 @@ See [`example.js`](example.js) if you want to quickly try it out. *(The example 
 
 ## API
 
-### instance = aperture()
+### instance = aperture([options])
+
+#### options
+
+##### ffmpegBinary
+
+Type: `string`<br>
+**Required on windows**
+
+Absolute path to the `ffmpeg.exe` binary.
 
 ### instance.startRecording([options])
 

--- a/index.js
+++ b/index.js
@@ -12,23 +12,23 @@ const IS_MACOS = process.platform === 'darwin';
 const IS_WINDOWS = process.platform === 'win32';
 
 class Aperture {
-  constructor({ ffmpegBinary } = {}) {
+  constructor({ffmpegBinary} = {}) {
     if (IS_MACOS) {
       macosVersion.assertGreaterThanOrEqualTo('10.10');
-      return
+      return;
     }
 
     if (IS_WINDOWS) {
       if (!ffmpegBinary) {
-        throw new Error('Missing `ffmpegBinary`')
+        throw new Error('Missing `ffmpegBinary`');
       }
 
       if (!path.isAbsolute(ffmpegBinary)) {
-        throw new Error('`ffmpegBinary` must be absolute path')
+        throw new Error('`ffmpegBinary` must be absolute path');
       }
 
-      this.ffmpegBinary = ffmpegBinary
-      return
+      this.ffmpegBinary = ffmpegBinary;
+      return;
     }
 
     if (IS_LINUX) {
@@ -47,7 +47,7 @@ class Aperture {
       });
     }
 
-    return Promise.reject(new Error('Not implemented yet'))
+    return Promise.reject(new Error('Not implemented yet'));
   }
 
   startRecording({
@@ -93,20 +93,19 @@ class Aperture {
 
         this.recorder = execa(path.join(__dirname, 'swift', 'main'), recorderOpts);
       } else if (IS_WINDOWS) {
-        const ffmpegArgs = [];
+        const ffmpegArgs = [
+          '-f', 'gdigrab',
+          '-i', 'desktop'
+        ];
 
         if (typeof cropArea === 'object') {
           ffmpegArgs.push(
             '-video_size', `${cropArea.width}x${cropArea.height}`,
-            '-f', 'gdigrab',
-            '-i', 'desktop',
             '-offset_x', cropArea.x,
             '-offset_y', cropArea.y
           );
         } else {
           ffmpegArgs.push(
-            '-f', 'gdigrab',
-            '-i', 'desktop',
             '-offset_x', 0,
             '-offset_y', 0
           );
@@ -178,7 +177,7 @@ class Aperture {
         this.recorder.stdin.write('quit\n');
         this.recorder.then(() => {
           delete this.recorder;
-          resolve(this.tmpPath)
+          resolve(this.tmpPath);
         })
         .catch(err => {
           reject(err.stderr ? new Error(err.stderr) : err);

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class Aperture {
           );
         }
 
-        ffmpegArgs.push('-framerate', fps, '-draw_mouse', Number(showCursor === true), this.tmpPath.replace('mp4', 'mpg'));
+        ffmpegArgs.push('-framerate', fps, '-draw_mouse', Number(showCursor === true), this.tmpPath);
         this.recorder = execa('ffmpeg', ffmpegArgs);
       }
 
@@ -159,10 +159,7 @@ class Aperture {
         this.recorder.stdin.write('quit\n');
         this.recorder.then(() => {
           delete this.recorder;
-          return execa('ffmpeg', ['-i', this.tmpPath.replace('mp4', 'mpg'), this.tmpPath]);
-        })
-        .then(() => {
-          resolve(this.tmpPath);
+          resolve(this.tmpPath)
         })
         .catch(err => {
           reject(err.stderr ? new Error(err.stderr) : err);

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ class Aperture {
         }
 
         ffmpegArgs.push('-framerate', fps, '-draw_mouse', Number(showCursor === true), this.tmpPath);
-        this.recorder = execa('ffmpeg', ffmpegArgs);
+        this.recorder = execa(this.ffmpegBinary, ffmpegArgs);
       }
 
       const timeout = setTimeout(() => {

--- a/index.js
+++ b/index.js
@@ -129,10 +129,11 @@ class Aperture {
           }
         });
       } else if (IS_WINDOWS) {
+        this.recorder.stderr.setEncoding('utf8');
         this.recorder.stderr.on('data', data => {
           debuglog(data);
 
-          if (data.toString('utf8').includes('encoder')) {
+          if (data.includes('encoder')) {
             clearTimeout(timeout);
             resolve(this.tmpPath);
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aperture",
   "version": "2.1.1",
-  "description": "Record the screen on macOS",
+  "description": "Record the screen on macOS & Windows",
   "license": "MIT",
   "repository": "wulkano/aperture",
   "author": "Matheus Fernandes <npm@matheus.top> (https://matheus.top)",


### PR DESCRIPTION
#37 without linux support

### todo
- [ ] Audio/audiosources
   http://zornsoftware.codenature.info/blog/record-screen-audio-with-ffmpeg.html
- [ ] Split startRecording functions per OS
- [x] [Figure out how to get ffmpeg (Should we ship the ffmpeg binary (.exe)?)](https://github.com/wulkano/aperture/pull/37#issuecomment-307482656)
  >No, that's too heavy and outside the scope of this plugin. We can add a ffmpegBinary option instead.