### PR TITLE
Add `movieFragmentInterval` option

### DIFF
--- a/Sources/Aperture/Aperture.swift
+++ b/Sources/Aperture/Aperture.swift
@@ -40,6 +40,7 @@ public final class Aperture: NSObject {
     highlightClicks: Bool,
     screenId: CGDirectDisplayID = .main,
     audioDevice: AVCaptureDevice? = .default(for: .audio),
+    movieFragmentInterval: Int64? = nil,
     videoCodec: String? = nil
   ) throws {
     self.destination = destination
@@ -60,7 +61,7 @@ public final class Aperture: NSObject {
 
     // Needed because otherwise there is no audio on videos longer than 10 seconds
     // http://stackoverflow.com/a/26769529/64949
-    output.movieFragmentInterval = .invalid
+    output.movieFragmentInterval = movieFragmentInterval != nil ? CMTimeMake(value: movieFragmentInterval!, timescale: 1) : .invalid
 
     if let audioDevice = audioDevice {
       if !audioDevice.hasMediaType(.audio) {


### PR DESCRIPTION
Add option to customize [movieFragmentInterval](https://developer.apple.com/documentation/avfoundation/avcapturemoviefileoutput/1387146-moviefragmentinterval). The default will be the same as before (`.invalid`)

Probably it didn't worked before because you were trying with `mp4` containers, but it does work with `mov` containers and it's nice to be able to change this option.