### PR TITLE
Add support for recording iOS screens

### DIFF
--- a/ScreenRecordingSample/.gitignore
+++ b/ScreenRecordingSample/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/ScreenRecordingSample/.gitignore
+++ b/ScreenRecordingSample/.gitignore
@@ -1,5 +1,4 @@
-.DS_Store
 /.build
 /Packages
 /*.xcodeproj
-xcuserdata/
+xcuserdata

--- a/ScreenRecordingSample/Package.swift
+++ b/ScreenRecordingSample/Package.swift
@@ -1,6 +1,4 @@
 // swift-tools-version:5.1
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
@@ -9,18 +7,20 @@ let package = Package(
         .macOS(.v10_12)
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(path: "../")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ScreenRecordingSample",
-            dependencies: ["Aperture"]),
+            dependencies: [
+              "Aperture"
+            ]
+        ),
         .testTarget(
             name: "ScreenRecordingSampleTests",
-            dependencies: ["ScreenRecordingSample"]),
+            dependencies: [
+              "ScreenRecordingSample"
+            ]
+        )
     ]
 )

--- a/ScreenRecordingSample/Package.swift
+++ b/ScreenRecordingSample/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ScreenRecordingSample",
+    platforms: [
+        .macOS(.v10_12)
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(path: "../")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "ScreenRecordingSample",
+            dependencies: ["Aperture"]),
+        .testTarget(
+            name: "ScreenRecordingSampleTests",
+            dependencies: ["ScreenRecordingSample"]),
+    ]
+)

--- a/ScreenRecordingSample/README.md
+++ b/ScreenRecordingSample/README.md
@@ -1,0 +1,3 @@
+# ScreenRecordingSample
+
+A description of this package.

--- a/ScreenRecordingSample/Sources/ScreenRecordingSample/main.swift
+++ b/ScreenRecordingSample/Sources/ScreenRecordingSample/main.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Aperture
+import AVFoundation
+
+let url = URL(fileURLWithPath: "./ios_screen.mp4")
+
+let aperture = try! Aperture(destination: url, iosDevice: AVCaptureDevice(uniqueID: Devices.ios()[0]["id"]!)!)
+
+aperture.start()
+
+sleep(5)
+
+aperture.stop()

--- a/ScreenRecordingSample/Tests/LinuxMain.swift
+++ b/ScreenRecordingSample/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import ScreenRecordingSampleTests
+
+var tests = [XCTestCaseEntry]()
+tests += ScreenRecordingSampleTests.allTests()
+XCTMain(tests)

--- a/ScreenRecordingSample/Tests/ScreenRecordingSampleTests/ScreenRecordingSampleTests.swift
+++ b/ScreenRecordingSample/Tests/ScreenRecordingSampleTests/ScreenRecordingSampleTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class ScreenRecordingSampleTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("ScreenRecordingSample")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/ScreenRecordingSample/Tests/ScreenRecordingSampleTests/XCTestManifests.swift
+++ b/ScreenRecordingSample/Tests/ScreenRecordingSampleTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(ScreenRecordingSampleTests.allTests),
+    ]
+}
+#endif

--- a/Sources/Aperture/Aperture.swift
+++ b/Sources/Aperture/Aperture.swift
@@ -24,32 +24,17 @@ public final class Aperture: NSObject {
   public var isPaused: Bool { output.isRecordingPaused }
   public let devices = Devices.self
 
-  // TODO: When targeting macOS 10.13, make the `videoCodec` option the type `AVVideoCodecType`.
-  public init(
+  private init(
     destination: URL,
-    framesPerSecond: Int,
-    cropRect: CGRect?,
-    showCursor: Bool,
-    highlightClicks: Bool,
-    screenId: CGDirectDisplayID = .main,
-    audioDevice: AVCaptureDevice? = .default(for: .audio),
-    videoCodec: String? = nil
+    input: AVCaptureInput,
+    output: AVCaptureMovieFileOutput,
+    audioDevice: AVCaptureDevice?,
+    videoCodec: String?
   ) throws {
     self.destination = destination
     session = AVCaptureSession()
 
-    let input = try AVCaptureScreenInput(displayID: screenId).unwrapOrThrow(ApertureError.invalidScreen)
-
-    input.minFrameDuration = CMTime(videoFramesPerSecond: framesPerSecond)
-
-    if let cropRect = cropRect {
-      input.cropRect = cropRect
-    }
-
-    input.capturesCursor = showCursor
-    input.capturesMouseClicks = highlightClicks
-
-    output = AVCaptureMovieFileOutput()
+    self.output = output
 
     // Needed because otherwise there is no audio on videos longer than 10 seconds
     // http://stackoverflow.com/a/26769529/64949
@@ -92,57 +77,80 @@ public final class Aperture: NSObject {
     super.init()
   }
 
-  public init(
+  // TODO: When targeting macOS 10.13, make the `videoCodec` option the type `AVVideoCodecType`.
+  /// Starts a capture session with the given screen id.
+  ///
+  /// To get a list of available screens, use `Devices.screen()`.
+  ///
+  /// Then pass the property `id` from those dictionaries to this initializer to start the capture session for the screen.
+  ///
+  /// - parameter destination: The destination URL where the captured video will be saved. Needs to be writable by current user.
+  /// - parameter framesPerSecond: The frames per second to be used for this capture.
+  /// - parameter cropRect: Optionally the screen capture can be cropped. Pass a CGRect to this initializer which represents the crop area.
+  /// - parameter showCursor: Whether to show the cursor in the captured video.
+  /// - parameter highlightClicks: Whether to highlight clicks in the captured video.
+  /// - parameter screenId: The id of the screen to be captured.
+  /// - parameter audioDevice: An optional audio device to capture during this session.
+  /// - parameter videoCodec: The video codec to use when capturing this session.
+  public convenience init(
+    destination: URL,
+    framesPerSecond: Int,
+    cropRect: CGRect?,
+    showCursor: Bool,
+    highlightClicks: Bool,
+    screenId: CGDirectDisplayID = .main,
+    audioDevice: AVCaptureDevice? = .default(for: .audio),
+    videoCodec: String? = nil
+  ) throws {
+    let input = try AVCaptureScreenInput(displayID: screenId).unwrapOrThrow(ApertureError.invalidScreen)
+
+    input.minFrameDuration = CMTime(videoFramesPerSecond: framesPerSecond)
+
+    if let cropRect = cropRect {
+      input.cropRect = cropRect
+    }
+
+    input.capturesCursor = showCursor
+    input.capturesMouseClicks = highlightClicks
+
+    try self.init(
+      destination: destination,
+      input: input,
+      output: AVCaptureMovieFileOutput(),
+      audioDevice: audioDevice,
+      videoCodec: videoCodec
+    )
+  }
+
+  /// Starts a capture session with the given iOS device.
+  ///
+  /// To get a list of connected iOS devices, use `Devices.iOS()`.
+  /// Use the property `id` from those dictionaries to create an `AVCaptureDevice`
+  /// like in the following example:
+  ///
+  /// `AVCaptureDevice(uniqueID: id)`
+  ///
+  /// Then pass this `AVCaptureDevice` to this initializer to start the capture session for an iOS device.
+  ///
+  /// - parameter destination: The destination URL where the captured video will be saved. Needs to be writable by current user.
+  /// - parameter iOSDevice: The iOS device to capture in this session.
+  /// - parameter audioDevice: An optional audio device to capture during this session.
+  /// - parameter videoCodec: The video codec to use when capturing this session.
+  public convenience init(
     destination: URL,
     iosDevice: AVCaptureDevice,
     audioDevice: AVCaptureDevice? = nil,
     videoCodec: String? = nil
   ) throws {
-    self.destination = destination
-    session = AVCaptureSession()
-
     let input = try AVCaptureDeviceInput(device: iosDevice)
 
-    // input.capturesCursor = showCursor
-    // input.capturesMouseClicks = highlightClicks
-
-    output = AVCaptureMovieFileOutput()
-
-    // Needed because otherwise there is no audio on videos longer than 10 seconds
-    // http://stackoverflow.com/a/26769529/64949
-    output.movieFragmentInterval = .invalid
-
-    if let audioDevice = audioDevice {
-      if !audioDevice.hasMediaType(.audio) {
-        throw ApertureError.invalidAudioDevice
-      }
-
-      let audioInput = try AVCaptureDeviceInput(device: audioDevice)
-
-      if session.canAddInput(audioInput) {
-        session.addInput(audioInput)
-      } else {
-        throw ApertureError.couldNotAddMic
-      }
-    }
-
-    if session.canAddInput(input) {
-      session.addInput(input)
-    } else {
-      throw ApertureError.couldNotAddScreen
-    }
-
-    if session.canAddOutput(output) {
-      session.addOutput(output)
-    } else {
-      throw ApertureError.couldNotAddOutput
-    }
-
-    if let videoCodec = videoCodec {
-      output.setOutputSettings([AVVideoCodecKey: videoCodec], for: output.connection(with: .video)!)
-    }
-
-    super.init()
+    try self.init(
+      destination: destination,
+      input: input,
+      output: AVCaptureMovieFileOutput(),
+      audioDevice: audioDevice,
+      videoCodec: videoCodec
+    )
   }
 
   public func start() {

--- a/Sources/Aperture/Devices.swift
+++ b/Sources/Aperture/Devices.swift
@@ -11,9 +11,7 @@ private func enableDalDevices() {
   )
   var allow: UInt32 = 1
   let sizeOfAllow = MemoryLayout<UInt32>.size
-  print("OSSTatus")
-  print(CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &property, 0, nil, UInt32(sizeOfAllow), &allow))
-  print("OSSTatus End")
+  CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &property, 0, nil, UInt32(sizeOfAllow), &allow)
 }
 
 public struct Devices {

--- a/Sources/Aperture/Devices.swift
+++ b/Sources/Aperture/Devices.swift
@@ -11,7 +11,9 @@ private func enableDalDevices() {
   )
   var allow: UInt32 = 1
   let sizeOfAllow = MemoryLayout<UInt32>.size
-  CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &property, 0, nil, UInt32(sizeOfAllow), &allow)
+  print("OSSTatus")
+  print(CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &property, 0, nil, UInt32(sizeOfAllow), &allow))
+  print("OSSTatus End")
 }
 
 public struct Devices {
@@ -37,7 +39,7 @@ public struct Devices {
   public static func ios() -> [[String: String]] {
     enableDalDevices()
     return AVCaptureDevice.devices(for: .muxed)
-      .filter { $0.localizedName == "iPhone" || $0.localizedName == "iPad" }
+      .filter { $0.localizedName.contains("iPhone") || $0.localizedName.contains("iPad") }
       .map {
         [
           "name": $0.localizedName,

--- a/screen_recording_sample.sh
+++ b/screen_recording_sample.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ScreenRecordingSample/
+swift run


### PR DESCRIPTION
Fixes #25 

I added a second initializer which accepts an `AVCaptureDevice` as the `iosDevice` and records the iOS screen together with an optional given audio device.

I made the audio device default to nil for recording iOS screens as I don't think it's a good default to record audio with the system default if you want to record an iOS screen. Callers can still set it to whatever they want.

I also changed the `Devices.ios()` function a little bit. It should now work like that.

The following is an example snippet which records 5 seconds of some connected iOS screen (the first one it finds) without audio.

```Swift
let url = URL(fileURLWithPath: "/Users/tester/Downloads/ios_screen.mp4")

let aperture = try! Aperture(destination: url, iosDevice: AVCaptureDevice(uniqueID: Devices.ios()[0]["id"]!)!)

aperture.start()

sleep(5)

aperture.stop()
```

@sindresorhus @skllcrn Could you review this for me?


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#25: Support recording iOS screen](https://issuehunt.io/repos/65488992/issues/25)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->