### PR TITLE
Add `scaleFactor` parameter

### DIFF
--- a/Sources/Aperture/Aperture.swift
+++ b/Sources/Aperture/Aperture.swift
@@ -86,6 +86,7 @@ public final class Aperture: NSObject {
 	- Parameter screenId: The ID of the screen to be captured.
 	- Parameter audioDevice: An optional audio device to capture.
 	- Parameter videoCodec: The video codec to use when capturing.
+	- Parameter scaleFactor: The factor by which video buffers are to be scaled
 	*/
 	public convenience init(
 		destination: URL,
@@ -95,7 +96,8 @@ public final class Aperture: NSObject {
 		highlightClicks: Bool = false,
 		screenId: CGDirectDisplayID = .main,
 		audioDevice: AVCaptureDevice? = .default(for: .audio),
-		videoCodec: AVVideoCodecType? = nil
+		videoCodec: AVVideoCodecType? = nil,
+		scaleFactor: CGFloat? = nil
 	) throws {
 		let input = try AVCaptureScreenInput(displayID: screenId).unwrapOrThrow(Error.invalidScreen)
 
@@ -103,6 +105,10 @@ public final class Aperture: NSObject {
 
 		if let cropRect = cropRect {
 			input.cropRect = cropRect
+		}
+
+		if let scaleFactor = scaleFactor {
+			input.scaleFactor = scaleFactor
 		}
 
 		input.capturesCursor = showCursor

--- a/Sources/Aperture/Aperture.swift
+++ b/Sources/Aperture/Aperture.swift
@@ -86,7 +86,7 @@ public final class Aperture: NSObject {
 	- Parameter screenId: The ID of the screen to be captured.
 	- Parameter audioDevice: An optional audio device to capture.
 	- Parameter videoCodec: The video codec to use when capturing.
-	- Parameter scaleFactor: The factor by which video buffers are to be scaled
+	- Parameter scaleFactor: The actual height and width of the capture will be multiplied by this number to create the height and width of the output.
 	*/
 	public convenience init(
 		destination: URL,
@@ -97,7 +97,7 @@ public final class Aperture: NSObject {
 		screenId: CGDirectDisplayID = .main,
 		audioDevice: AVCaptureDevice? = .default(for: .audio),
 		videoCodec: AVVideoCodecType? = nil,
-		scaleFactor: CGFloat? = nil
+		scaleFactor: Double = 1
 	) throws {
 		let input = try AVCaptureScreenInput(displayID: screenId).unwrapOrThrow(Error.invalidScreen)
 
@@ -107,9 +107,7 @@ public final class Aperture: NSObject {
 			input.cropRect = cropRect
 		}
 
-		if let scaleFactor = scaleFactor {
-			input.scaleFactor = scaleFactor
-		}
+        input.scaleFactor = CGFloat(scaleFactor)
 
 		input.capturesCursor = showCursor
 		input.capturesMouseClicks = highlightClicks

--- a/Sources/Aperture/Aperture.swift
+++ b/Sources/Aperture/Aperture.swift
@@ -107,8 +107,7 @@ public final class Aperture: NSObject {
 			input.cropRect = cropRect
 		}
 
-        input.scaleFactor = CGFloat(scaleFactor)
-
+		input.scaleFactor = CGFloat(scaleFactor)
 		input.capturesCursor = showCursor
 		input.capturesMouseClicks = highlightClicks
 


### PR DESCRIPTION
This lets consumers specify the scaleFactor to use when talking to
`AVCaptureScreenInput`. This was useful to me for keeping file sizes
down, particularly on my Macbook Pro's retina display.