### PR TITLE
Add note about building the binary to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ pod 'Aperture'
 
 See the [source](Sources/Aperture/Aperture.swift) for now.
 
+## Building 
+
+The build script can be found in the sibling Node.js wrapper [`package.json`](https://github.com/wulkano/aperture-node/blob/main/package.json).
+
 ## Related
 
 - [aperture-node](https://github.com/wulkano/aperture-node) - Node.js wrapper


### PR DESCRIPTION
It took me a while to find the proper `swift` command because it was in the other repo.