### PR TITLE
Fix macOS version in Package.swift

### DIFF
--- a/Example/Package.swift
+++ b/Example/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
 	name: "Example",
 	platforms: [
-		.macOS(.v10_12)
+		.macOS(.v10_13)
 	],
 	dependencies: [
 		.package(path: "..")


### PR DESCRIPTION
Updated from macOS v10_12 -> v10_13 to allow `example-ios.sh` to run.